### PR TITLE
vendor: cesium.devices: Add angler

### DIFF
--- a/cesium.devices
+++ b/cesium.devices
@@ -9,3 +9,4 @@ violet
 whyred
 X00T
 X00P
+angler


### PR DESCRIPTION
Oo I am sure lazy gotcha pull all official devices else RIP automated builds